### PR TITLE
fix: remove hardcoded architecture in zarf yamls

### DIFF
--- a/src/minio/zarf.yaml
+++ b/src/minio/zarf.yaml
@@ -5,7 +5,7 @@ metadata:
   # x-release-please-start-version
   version: "0.0.1"
   # x-release-please-end
-  architecture: amd64
+
 
 variables:
   - name: BUCKETS

--- a/src/postgres/zarf.yaml
+++ b/src/postgres/zarf.yaml
@@ -5,7 +5,7 @@ metadata:
   # x-release-please-start-version
   version: "0.0.1"
   # x-release-please-end
-  architecture: amd64
+
 
 variables:
   - name: DB_NAME

--- a/src/redis/zarf.yaml
+++ b/src/redis/zarf.yaml
@@ -5,7 +5,7 @@ metadata:
   # x-release-please-start-version
   version: "0.0.1"
   # x-release-please-end
-  architecture: amd64
+
 
 components:
   - name: redis-istio-exceptions


### PR DESCRIPTION
Remove hardcode arch from dev dependencies zarf.yamls. Looks like publish step was already set up for doing both amd64 and arm64.